### PR TITLE
EnterpriseList 랜덤순서 / navigate 해당 주소 연결 임시

### DIFF
--- a/src/main/client/src/components/units/developers/DeveloperProfile.jsx
+++ b/src/main/client/src/components/units/developers/DeveloperProfile.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import {
   Div,
   ProfileImage,
@@ -13,6 +14,8 @@ import {
 } from "./DeveloperProfile.style";
 
 function DeveloperProfile({ unitColor, realName, nation, role, techStacks }) {
+  const navigate = useNavigate();
+
   return (
     <Div unitColor={unitColor}>
       <ProfileImage
@@ -25,7 +28,7 @@ function DeveloperProfile({ unitColor, realName, nation, role, techStacks }) {
             <Name>{realName}</Name>
             <Nation>{nation}</Nation>
           </Title>
-          <MoreButton>자세히 보기</MoreButton>
+          <MoreButton onClick={()=> navigate(`/${realName}`)}>자세히 보기</MoreButton>
         </TitleBox>
         <Role>{role}</Role>
         <TechStackBox>

--- a/src/main/client/src/components/units/enterprises/EnterpriseList.jsx
+++ b/src/main/client/src/components/units/enterprises/EnterpriseList.jsx
@@ -16,6 +16,9 @@ function EnterpriseList() {
 
   console.log(JSON.stringify(enterprise, null, 3));
 
+  // 데이터를 shuffle 한다면
+  // const shuffle = enterprise.sort(() => Math.random() - 0.5);
+
   return (
     <Section>
       {enterprise.map((m, indexA) => {
@@ -23,8 +26,10 @@ function EnterpriseList() {
           <EnterpriseProfile
             key={indexA}
             enterpriseName={m.enterpriseName}
-            notices={m.notices}
+            title={m.title}
+            techStacks={m.techStacks}
             enterpriseLocation={m.enterpriseLocation}
+            annual={m.annual}
           />
         );
       })}

--- a/src/main/client/src/components/units/enterprises/EnterpriseList.style.js
+++ b/src/main/client/src/components/units/enterprises/EnterpriseList.style.js
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 export const Section = styled.section`
   display: flex;
+  flex-wrap: wrap;
   width: 950px;
   text-align: center;
   margin: 20px auto;

--- a/src/main/client/src/components/units/enterprises/EnterpriseProfile.jsx
+++ b/src/main/client/src/components/units/enterprises/EnterpriseProfile.jsx
@@ -1,32 +1,47 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Div, ProfileImage } from "./EnterpriseProfile.style";
 
-function EnterpriseProfile({ enterpriseName, notices, enterpriseLocation }) {
+function EnterpriseProfile({
+  enterpriseName,
+  title,
+  techStacks,
+  enterpriseLocation,
+  annual,
+}) {
+  const navigate = useNavigate();
+
+  const [limit, setLimit] = useState(12);  // eslint-disable-line no-unused-vars
+  const toggleEllipsis = (str, limit) => {
+    return {
+      string: str.slice(0, limit),
+      isShowMore: str.length > limit,
+    };
+  };
+
   return (
-    <Div>
+    <Div onClick={() => navigate(`/${enterpriseName}`)}>
       <ProfileImage
         alt=""
         src={require("components/units/enterprises/testimage.jpeg")}
       />
       <p>{enterpriseName}</p>
-      {notices.map((n, indexB) => {
-        return (
-          <div key={indexB}>
-            <h3>{n.title}</h3>
-            <p>
-              {enterpriseLocation} · {n.annual}
+      <h3>
+        {toggleEllipsis(title, limit).string}
+        {toggleEllipsis(title, limit).isShowMore && <span>...</span>}
+      </h3>
+      {/* <div style={{ display: "flex" }}>
+        {techStacks.map((t, indexB) => {
+          return (
+            <p style={{ fontSize: "12px", margin: "5px" }} key={indexB}>
+              {t.techName}
             </p>
-            <div style={{ display: "flex" }}>
-              {n.techStacks.map((t, indexC) => {
-                return (
-                  <p style={{ fontSize: "12px", margin:"5px" }} key={indexC}>
-                    {t.techName}
-                  </p>
-                );
-              })}
-            </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div> */}
+      <p>
+        {enterpriseLocation} · {annual}
+      </p>
     </Div>
   );
 }

--- a/src/main/client/src/components/units/enterprises/EnterpriseProfile.style.js
+++ b/src/main/client/src/components/units/enterprises/EnterpriseProfile.style.js
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
 export const Div = styled.div`
-  width: 235px;
+  width: 210px;
   height: 200px;
   text-align: center;
   margin: 20px auto;
-  /* border: 1px solid #000; */
+  border: 1px solid #000;
 `;
 export const ProfileImage = styled.img`
   width: 200px;


### PR DESCRIPTION
EnterpriseList 리스트를 map 하기 전에 sort와 Math.random을 활용하여 랜덤 순서로 출력하는 것을 테스트
근데 라이트 모드, 다크 모드로 전환 시에도 바뀌는 문제가 있어 일단 주석처리
EnterpriseList의 경우 디자인 대폭 수정 예정

DeveloperList, EnterpriseList에서 각각 클릭 시 해당 프로필의 기업명 or 이름으로 작성된 도메인으로 navigate

ex ) kim 클릭 시 domain/kim 페이지로 이동